### PR TITLE
Add issue templates for bugs and feature requests

### DIFF
--- a/bug_report.md
+++ b/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug to help us improve the project
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+## Description
+Describe the bug clearly and concisely.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+What you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+- OS:
+- Browser:
+- Version:
+
+## Priority
+- [ ] High
+- [ ] Medium
+- [ ] Low

--- a/feature_request.md
+++ b/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest a new idea or enhancement for the project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+
+---
+
+## Description
+A clear and concise description of the feature you’d like to see.
+
+## Justification
+Why is this feature useful or necessary?
+
+## Possible Solution
+Describe how it could work.
+
+## Additional Context
+Any other context or screenshots about the feature request.


### PR DESCRIPTION
This PR adds two GitHub issue templates:
- `bug_report.md` for bug reports
- `feature_request.md` for suggestions

These templates aim to standardize issue reporting and improve collaboration. Resolves #21.